### PR TITLE
[figma]:update to 0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterio-icons",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "xterio platform icon components",
   "main": "dist/xterio-icons.cjs.js",
   "module": "dist/xterio-icons.esm.js",


### PR DESCRIPTION
重新修复了图标 icon_deposit_to_game_16