### PR TITLE
[figma]:update to 0.1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterio-icons",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "xterio platform icon components",
   "main": "dist/xterio-icons.cjs.js",
   "module": "dist/xterio-icons.esm.js",


### PR DESCRIPTION
补充增加默认token图标，三个尺寸：16X16、24X24、32X32